### PR TITLE
Release v1.0.197

### DIFF
--- a/App/AppInfo/Launcher/JoplinPortable.ini
+++ b/App/AppInfo/Launcher/JoplinPortable.ini
@@ -3,4 +3,4 @@ ProgramExecutable=Joplin.exe
 CommandLineArguments="--profile %PAL:DataDir%\Joplin"
 DirectoryMoveOK=yes
 SupportsUNC=yes
-MinOS=Vista
+MinOS=7

--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -18,8 +18,8 @@ Freeware=true
 CommercialUse=true
 
 [Version]
-PackageVersion=1.0.196.0
-DisplayVersion=1.0.196-beta5-uroesch
+PackageVersion=1.0.195.0
+DisplayVersion=1.0.195-beta6-uroesch
 
 [Control]
 Icons=1

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,9 +1,9 @@
 [Version]
-Package = 1.0.196.0
-Display = 1.0.196-beta5-uroesch
+Package = 1.0.195.0
+Display = 1.0.195-beta6-uroesch
 
 [Archive]
-URL1         = https://github.com/laurent22/joplin/releases/download/v1.0.196/JoplinPortable.exe
-Checksum1    = SHA256:a6d9b9a3b8cfc090ac7d0b5950320f561e41476dc2b26c6a2d4f74cda9e9ccfd
+URL1         = https://github.com/laurent22/joplin/releases/download/v1.0.195/JoplinPortable.exe
+Checksum1    = SHA256:C1F3FFB67A42262ADD1BAB7E609D34389DB00AFEDA74C4395B62A3F7B1DD97B3
 TargetName1  = Joplin.exe
 ExtractName1 = JoplinPortable.exe


### PR DESCRIPTION
Summary:
  * Upstream release of v1.0.197.
  * Set minimum os to 7 in accordance with
    Electron manual.