### PR TITLE
Revert "Merge pull request #8 from uroesch/release/v1.0.197"

### DIFF
--- a/App/AppInfo/Launcher/JoplinPortable.ini
+++ b/App/AppInfo/Launcher/JoplinPortable.ini
@@ -3,4 +3,4 @@ ProgramExecutable=Joplin.exe
 CommandLineArguments="--profile %PAL:DataDir%\Joplin"
 DirectoryMoveOK=yes
 SupportsUNC=yes
-MinOS=7
+MinOS=Vista

--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -18,8 +18,8 @@ Freeware=true
 CommercialUse=true
 
 [Version]
-PackageVersion=1.0.195.0
-DisplayVersion=1.0.195-beta6-uroesch
+PackageVersion=1.0.196.0
+DisplayVersion=1.0.196-beta5-uroesch
 
 [Control]
 Icons=1

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,9 +1,9 @@
 [Version]
-Package = 1.0.195.0
-Display = 1.0.195-beta6-uroesch
+Package = 1.0.196.0
+Display = 1.0.196-beta5-uroesch
 
 [Archive]
-URL1         = https://github.com/laurent22/joplin/releases/download/v1.0.195/JoplinPortable.exe
-Checksum1    = SHA256:C1F3FFB67A42262ADD1BAB7E609D34389DB00AFEDA74C4395B62A3F7B1DD97B3
+URL1         = https://github.com/laurent22/joplin/releases/download/v1.0.196/JoplinPortable.exe
+Checksum1    = SHA256:a6d9b9a3b8cfc090ac7d0b5950320f561e41476dc2b26c6a2d4f74cda9e9ccfd
 TargetName1  = Joplin.exe
 ExtractName1 = JoplinPortable.exe


### PR DESCRIPTION
Summary:
  * update.ini was not set to 1.0.197

This reverts commit 8aec679d10041d352addd222728bdbe68c06b261, reversing
changes made to d1139be669106622a04eda11d92585f8903ceeee.